### PR TITLE
Fix some bugs when seeking

### DIFF
--- a/jcplayer/src/main/java/com/example/jean/jcplayer/JcPlayerManager.kt
+++ b/jcplayer/src/main/java/com/example/jean/jcplayer/JcPlayerManager.kt
@@ -147,6 +147,15 @@ class JcPlayerManager private constructor(private val serviceConnection: JcServi
     }
 
     /**
+     * Notifies on seek completed for the service listeners
+     */
+    private fun notifyOnSeekCompleted(status: JcStatus) {
+        for (listener in managerListeners) {
+            listener.onSeekCompleted(status)
+        }
+    }
+
+    /**
      * Connects with audio service.
      */
     private fun initService(connectionListener: ((service: JcPlayerService?) -> Unit)? = null) =
@@ -179,6 +188,7 @@ class JcPlayerManager private constructor(private val serviceConnection: JcServi
 
                 service.onPreparedListener = { notifyOnPrepared(it) }
                 service.onTimeChangedListener = { notifyOnTimeChanged(it) }
+                service.onSeekCompletedListener = { notifyOnSeekCompleted(it) }
                 service.onCompletedListener = { notifyOnCompleted() }
                 service.onContinueListener = { notifyOnContinue(it) }
 

--- a/jcplayer/src/main/java/com/example/jean/jcplayer/service/JcPlayerManagerListener.kt
+++ b/jcplayer/src/main/java/com/example/jean/jcplayer/service/JcPlayerManagerListener.kt
@@ -43,6 +43,11 @@ interface JcPlayerManagerListener {
     fun onTimeChanged(status: JcStatus)
 
     /**
+     * Called when seeking completed.
+     */
+    fun onSeekCompleted(status: JcStatus)
+
+    /**
      * Notifies some error.
      * @param throwable The error.
      */

--- a/jcplayer/src/main/java/com/example/jean/jcplayer/service/JcPlayerService.kt
+++ b/jcplayer/src/main/java/com/example/jean/jcplayer/service/JcPlayerService.kt
@@ -26,7 +26,7 @@ import java.util.concurrent.TimeUnit
  * Jesus loves you.
  */
 class JcPlayerService : Service(), MediaPlayer.OnPreparedListener, MediaPlayer.OnCompletionListener,
-        MediaPlayer.OnBufferingUpdateListener, MediaPlayer.OnErrorListener {
+        MediaPlayer.OnBufferingUpdateListener, MediaPlayer.OnSeekCompleteListener, MediaPlayer.OnErrorListener {
 
     private val binder = JcPlayerServiceBinder()
 
@@ -38,6 +38,8 @@ class JcPlayerService : Service(), MediaPlayer.OnPreparedListener, MediaPlayer.O
     var onPreparedListener: ((JcStatus) -> Unit)? = null
 
     var onTimeChangedListener: ((JcStatus) -> Unit)? = null
+
+    var onSeekCompletedListener: ((JcStatus) -> Unit)? = null
 
     var onContinueListener: ((JcStatus) -> Unit)? = null
 
@@ -125,6 +127,7 @@ class JcPlayerService : Service(), MediaPlayer.OnPreparedListener, MediaPlayer.O
                         it.setOnPreparedListener(this)
                         it.setOnBufferingUpdateListener(this)
                         it.setOnCompletionListener(this)
+                        it.setOnSeekCompleteListener(this)
                         it.setOnErrorListener(this)
 
                         status = updateStatus(jcAudio, JcStatus.PlayState.PREPARING)
@@ -143,13 +146,16 @@ class JcPlayerService : Service(), MediaPlayer.OnPreparedListener, MediaPlayer.O
     fun seekTo(time: Int) {
         Log.d("time = ", Integer.toString(time))
         mediaPlayer?.seekTo(time)
-        onTimeChangedListener?.invoke(updateStatus(currentAudio, JcStatus.PlayState.CONTINUE))
     }
 
     override fun onBufferingUpdate(mediaPlayer: MediaPlayer, i: Int) {}
 
     override fun onCompletion(mediaPlayer: MediaPlayer) {
         onCompletedListener?.invoke()
+    }
+
+    override fun onSeekComplete(mediaPlayer: MediaPlayer) {
+        onSeekCompletedListener?.invoke(updateStatus(currentAudio, JcStatus.PlayState.CONTINUE))
     }
 
     override fun onError(mediaPlayer: MediaPlayer, i: Int, i1: Int): Boolean {

--- a/jcplayer/src/main/java/com/example/jean/jcplayer/service/JcPlayerService.kt
+++ b/jcplayer/src/main/java/com/example/jean/jcplayer/service/JcPlayerService.kt
@@ -161,7 +161,7 @@ class JcPlayerService : Service(), MediaPlayer.OnPreparedListener, MediaPlayer.O
     }
 
     override fun onSeekComplete(mediaPlayer: MediaPlayer) {
-        val status = updateStatus(currentAudio, JcStatus.PlayState.CONTINUE)
+        val status = updateStatus(currentAudio, jcStatus.playState)
         serviceListener?.onSeekCompletedListener(status)
     }
 

--- a/jcplayer/src/main/java/com/example/jean/jcplayer/service/notification/JcNotificationPlayer.kt
+++ b/jcplayer/src/main/java/com/example/jean/jcplayer/service/notification/JcNotificationPlayer.kt
@@ -144,6 +144,10 @@ class JcNotificationPlayer private constructor(private val context: Context) : J
         createNotificationPlayer(title, iconResource)
     }
 
+    override fun onSeekCompleted(status: JcStatus) {
+
+    }
+
 
     fun destroyNotificationIfExists() {
         try {

--- a/jcplayer/src/main/java/com/example/jean/jcplayer/view/JcPlayerView.kt
+++ b/jcplayer/src/main/java/com/example/jean/jcplayer/view/JcPlayerView.kt
@@ -459,6 +459,9 @@ class JcPlayerView : LinearLayout, View.OnClickListener, SeekBar.OnSeekBarChange
 
     override fun onSeekCompleted(status: JcStatus) {
         dismissProgressBar()
+        if (status.playState == JcStatus.PlayState.PAUSE) {
+            showPlayButton()
+        }
 
         val currentPosition = status.currentPosition.toInt()
         seekBar?.post { seekBar?.progress = currentPosition }

--- a/jcplayer/src/main/java/com/example/jean/jcplayer/view/JcPlayerView.kt
+++ b/jcplayer/src/main/java/com/example/jean/jcplayer/view/JcPlayerView.kt
@@ -483,12 +483,8 @@ class JcPlayerView : LinearLayout, View.OnClickListener, SeekBar.OnSeekBarChange
     override fun onStartTrackingTouch(seekBar: SeekBar) {}
 
     override fun onStopTrackingTouch(seekBar: SeekBar) {
-        if (jcPlayerManager.currentAudio != null) {
-            jcPlayerManager.let {
-                it.seekTo(seekBar.progress)
-                showProgressBar()
-            }
-        }
+        jcPlayerManager.seekTo(seekBar.progress)
+        showProgressBar()
     }
 
     /**

--- a/jcplayer/src/main/java/com/example/jean/jcplayer/view/JcPlayerView.kt
+++ b/jcplayer/src/main/java/com/example/jean/jcplayer/view/JcPlayerView.kt
@@ -432,13 +432,7 @@ class JcPlayerView : LinearLayout, View.OnClickListener, SeekBar.OnSeekBarChange
         txtDuration?.post { txtDuration?.text = toTimeSongString(duration) }
     }
 
-    override fun onProgressChanged(seekBar: SeekBar, i: Int, fromUser: Boolean) {
-        jcPlayerManager.let {
-            if (fromUser) {
-                it.seekTo(i)
-            }
-        }
-    }
+    override fun onProgressChanged(seekBar: SeekBar, i: Int, fromUser: Boolean) {}
 
     override fun onCompletedAudio() {
         resetPlayerInfo()
@@ -469,6 +463,14 @@ class JcPlayerView : LinearLayout, View.OnClickListener, SeekBar.OnSeekBarChange
         txtCurrentDuration?.post { txtCurrentDuration?.text = toTimeSongString(currentPosition) }
     }
 
+    override fun onSeekCompleted(status: JcStatus) {
+        dismissProgressBar()
+
+        val currentPosition = status.currentPosition.toInt()
+        seekBar?.post { seekBar?.progress = currentPosition }
+        txtCurrentDuration?.post { txtCurrentDuration?.text = toTimeSongString(currentPosition) }
+    }
+
     override fun onJcpError(throwable: Throwable) {
         // TODO
 //        jcPlayerManager.currentAudio?.let {
@@ -476,14 +478,15 @@ class JcPlayerView : LinearLayout, View.OnClickListener, SeekBar.OnSeekBarChange
 //        }
     }
 
-    override fun onStartTrackingTouch(seekBar: SeekBar) {
-        if (jcPlayerManager.currentAudio != null) {
-            showProgressBar()
-        }
-    }
+    override fun onStartTrackingTouch(seekBar: SeekBar) {}
 
     override fun onStopTrackingTouch(seekBar: SeekBar) {
-        dismissProgressBar()
+        if (jcPlayerManager.currentAudio != null) {
+            jcPlayerManager.let {
+                it.seekTo(seekBar.progress)
+                showProgressBar()
+            }
+        }
     }
 
     /**

--- a/sample/src/main/java/com/example/jean/jcplayersample/AudioAdapter.java
+++ b/sample/src/main/java/com/example/jean/jcplayersample/AudioAdapter.java
@@ -36,7 +36,7 @@ public class AudioAdapter extends RecyclerView.Adapter<AudioAdapter.AudioAdapter
 
     @Override
     public long getItemId(int position) {
-        return jcAudioList.get(position).getId();
+        return position;
     }
 
     @Override

--- a/sample/src/main/java/com/example/jean/jcplayersample/MainActivity.java
+++ b/sample/src/main/java/com/example/jean/jcplayersample/MainActivity.java
@@ -160,6 +160,11 @@ public class MainActivity extends AppCompatActivity
     }
 
     @Override
+    public void onSeekCompleted(JcStatus status) {
+
+    }
+
+    @Override
     public void onJcpError(@NonNull Throwable throwable) {
 
     }

--- a/sample/src/main/java/com/example/jean/jcplayersample/MainActivity.java
+++ b/sample/src/main/java/com/example/jean/jcplayersample/MainActivity.java
@@ -175,7 +175,7 @@ public class MainActivity extends AppCompatActivity
     }
 
     private void updateProgress(final JcStatus jcStatus) {
-        Log.d(TAG, "Song id = " + jcStatus.getJcAudio().getId() + "Song duration = " + jcStatus.getDuration()
+        Log.d(TAG, "Song duration = " + jcStatus.getDuration()
                 + "\n song position = " + jcStatus.getCurrentPosition());
 
         runOnUiThread(new Runnable() {

--- a/sample/src/main/java/com/example/jean/jcplayersample/MainActivity.java
+++ b/sample/src/main/java/com/example/jean/jcplayersample/MainActivity.java
@@ -160,8 +160,8 @@ public class MainActivity extends AppCompatActivity
     }
 
     @Override
-    public void onSeekCompleted(JcStatus status) {
-
+    public void onSeekCompleted(@NonNull JcStatus status) {
+        updateProgress(status);
     }
 
     @Override


### PR DESCRIPTION
Thank you for your great library.
When I was using this library, I have found some bugs when seeking audio.

**Problems**
1. When seeking started, 'OnStartTrackingTouch' in 'JcPlayerView' immediately call function 'showProgressBar(). So 'OnStopTrackingTouch' can't call function 'dismissProgressBar()' because 'seekBar' is already disabled.

2. 'OnProgressChanged' in 'JcPlayerView' call function 'seekTo' every progress changing even just dragging seek bar.

So I fixed these bugs.

**Solutions**
1. I moved functions 'showProgressBar()' and 'seekTo()' to 'OnStopTrackingTouch()'.
And I added new Listener 'OnSeekComplete'. It calls 'dismissProgressBar()' when seeking completed.

**Here is before & after**
Before
![before](https://user-images.githubusercontent.com/18042375/43584665-fdc20120-969d-11e8-8f3a-7e6af2f026a0.gif)

After
![after](https://user-images.githubusercontent.com/18042375/43584666-fdeb723a-969d-11e8-82b9-2e73dcd344fe.gif)
